### PR TITLE
PEP 386->PEP440 for versioning in meta-yaml.rst

### DIFF
--- a/docs/source/building/meta-yaml.rst
+++ b/docs/source/building/meta-yaml.rst
@@ -32,7 +32,7 @@ Lower case name of package, may contain '-' but no spaces
 Package version
 ~~~~~~~~~~~~~~~
 
-Version of package. Should use the PEP-386 verlib conventions. Note that YAML will 
+Version of package. Should use the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_. verlib conventions. Note that YAML will 
 interpret versions like 1.0 as floats, meaning that 0.10 will be the same as 0.1. To
 avoid this, always put the version in quotes, so that it will be interpreted as a 
 string.


### PR DESCRIPTION
According to conda-build/versioneer.py PEP 440 is used, which supercedes PEP 386.
